### PR TITLE
Update homepage to match git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "homepage": "https://sei-uxdi-collab.github.io/maps/",
+  "homepage": "https://sei-uxdi-collab.github.io/work_from_roam-client/",
   "version": "0.1.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Git repository was changed to /work_from_roam-client
updated homepage to match github repo