### PR TITLE
Alex new workspace

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -53,27 +53,3 @@ export const changePassword = (passwords, user) => {
     }
   })
 }
-
-export const createReview = (params) => {
-  return axios({
-    method: 'post',
-    url: apiUrl + '/reviews',
-    data: {
-      review: {
-        work_space_id: params.id,
-        rating: params.rating,
-        noise: params.noise,
-        bathroom: params.bathroom,
-        seating: params.seating,
-        coffee: params.coffee ? "5" : "0",
-        outlet: params.outlet ? "5" : "0",
-        food: params.food ? "5" : "0",
-        wifi: params.wifi,
-        note: params.note
-      }
-    },
-    headers: {
-      Authorization: `Token token=${params.token}`
-    }
-  })
-}

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -53,3 +53,27 @@ export const changePassword = (passwords, user) => {
     }
   })
 }
+
+export const createReview = (params) => {
+  return axios({
+    method: 'post',
+    url: apiUrl + '/reviews',
+    data: {
+      review: {
+        work_space_id: params.id,
+        rating: params.rating,
+        noise: params.noise,
+        bathroom: params.bathroom,
+        seating: params.seating,
+        coffee: params.coffee ? "5" : "0",
+        outlet: params.outlet ? "5" : "0",
+        food: params.food ? "5" : "0",
+        wifi: params.wifi,
+        note: params.note
+      }
+    },
+    headers: {
+      Authorization: `Token token=${params.token}`
+    }
+  })
+}

--- a/src/api/create.js
+++ b/src/api/create.js
@@ -1,0 +1,47 @@
+import apiUrl from '../apiConfig'
+import axios from 'axios'
+
+export const createReview = (params) => {
+    return axios({
+      method: 'post',
+      url: apiUrl + '/reviews',
+      data: {
+        review: {
+          work_space_id: params.id,
+          rating: params.rating,
+          noise: params.noise,
+          bathroom: params.bathroom,
+          seating: params.seating,
+          coffee: params.coffee ? "5" : "0",
+          outlet: params.outlet ? "5" : "0",
+          food: params.food ? "5" : "0",
+          wifi: params.wifi,
+          note: params.note
+        }
+      },
+      headers: {
+        Authorization: `Token token=${params.token}`
+      }
+    })
+  }
+  
+  export const createWorkspace = (params) => {
+    return axios({
+      method: 'post',
+      url: apiUrl + '/work_spaces',
+      data: {
+        work_space: {
+          place_id: params.placeId,
+          lat: params.lat,
+          lng: params.lng,
+          name: params.name,
+          address: params.address,
+          photo: params.photo,
+        }
+      },
+      headers: {
+        Authorization: `Token token=${params.token}`
+      }
+    })
+  }
+  

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -73,7 +73,7 @@ class App extends React.Component {
             />
           ))}
 
-        <Route path='/work_spaces/:id/create-review'>
+        <Route path='/work_spaces/create-review'>
           <ReviewCreate
             user={user}
             alert={this.alert}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -73,7 +73,7 @@ class App extends React.Component {
             />
           ))}
 
-        <Route path='/work_spaces/create-review'>
+        <Route path='/create-review'>
           <ReviewCreate
             user={user}
             alert={this.alert}

--- a/src/components/GoogleMap/GoogleMap.js
+++ b/src/components/GoogleMap/GoogleMap.js
@@ -93,7 +93,7 @@ class GoogleMap extends React.Component {
         this.props.setApp({ mapCenter, poiLocation, placeId })
 
         this.getPlaceDetails(map, placeId)
-        this.props.history.push('/create-workspace')
+        this.props.history.push('/workspace')
     }
 
     handleClick = (props, map, event) => {

--- a/src/components/GoogleMap/GoogleMap.js
+++ b/src/components/GoogleMap/GoogleMap.js
@@ -82,11 +82,20 @@ class GoogleMap extends React.Component {
         }
     }
 
+    findExistingWorkspace = placeId => {
+        const dataId = this.props.allData.findIndex(workspace => workspace.place_id === placeId)
+        if (dataId >= 0) {
+            this.props.setApp({ currentWorkspace: this.props.allData[dataId]})
+        }
+    }
+
     handlePOI = (map, event) => {
         this.props.setApp({ placeData: null, currentWorkspace: null })
         const placeId = event.placeId
         const poiLocation = { lat: event.latLng.lat(), lng: event.latLng.lng() }
         const mapCenter = poiLocation
+
+        this.findExistingWorkspace(placeId)
         // turn infoWindow on to overwrite default poi window
         this.setState({ showPOI: true })
   

--- a/src/components/GoogleMap/GoogleMap.js
+++ b/src/components/GoogleMap/GoogleMap.js
@@ -83,7 +83,7 @@ class GoogleMap extends React.Component {
     }
 
     handlePOI = (map, event) => {
-        this.props.setApp({ placeData: null })
+        this.props.setApp({ placeData: null, currentWorkspace: null })
         const placeId = event.placeId
         const poiLocation = { lat: event.latLng.lat(), lng: event.latLng.lng() }
         const mapCenter = poiLocation

--- a/src/components/WorkSpace/WorkSpace.js
+++ b/src/components/WorkSpace/WorkSpace.js
@@ -52,7 +52,7 @@ class WorkSpace extends React.Component {
               <div style={{ textAlign: 'center' }}>
                 <h3>Be the first to write a  <Button
                 data={this.props.data.id}
-                href={`#work_spaces/${this.props.data.id}/create-review`}
+                href={`#work_spaces/create-review`}
               >
                 Review
               </Button> for</h3>

--- a/src/components/WorkSpace/WorkSpace.js
+++ b/src/components/WorkSpace/WorkSpace.js
@@ -43,7 +43,7 @@ class WorkSpace extends React.Component {
         photo = '../../image_not_found.png'
       }
 
-      if(this.props.data.reviews.length < 1) {
+      if(!this.props.data || this.props.data.reviews.length < 1) {
         return (
             <div className='workspace'>
               <Link to='/'>
@@ -51,8 +51,7 @@ class WorkSpace extends React.Component {
               </Link>
               <div style={{ textAlign: 'center' }}>
                 <h3>Be the first to write a  <Button
-                data={this.props.data.id}
-                href={`#work_spaces/create-review`}
+                href={`#/create-review`}
               >
                 Review
               </Button> for</h3>
@@ -188,7 +187,7 @@ class WorkSpace extends React.Component {
                     <Button
                       className='reviewButton'
                       data={this.props.data.id}
-                      href={`#work_spaces/${this.props.data.id}/create-review`}
+                      href={`#/create-review`}
                     >
                       Leave a Review
                     </Button>


### PR DESCRIPTION
Clicking on a point of interest will redirect to '/workspace'
Workspace links to '/create-review'
ReviewCreate will know from `props.currentWorkspace` if it is a new or existing workspace
Existing workspace functions the same.
New workspace will first create a workspace, then review, on submit.

Working on this issue, I noticed an existing defect that allows users to overwrite an existing workspace. If user creates a new workspace that already exists, the new marker will cover up the existing marker, making the old workspace unclickable. I will create a new issue for this on the frontend. We should also prevent the API from creating a new workspace if an existing workspace has the same place_id.