### PR TITLE
Fix cannot render component inside Info component

### DIFF
--- a/src/components/Info/Info.js
+++ b/src/components/Info/Info.js
@@ -29,6 +29,7 @@ function Info(props) {
           className="info-text"
           dangerouslySetInnerHTML={{ __html: props.content }}
         />
+        {props.children}
       </div>
     </div>
   );


### PR DESCRIPTION
I was unable to render a component using `dangerouslySetInnerHTML` perhaps this is not possible or recommended?
Added `{props.children}` to render components or html elements passed as children to <Info /> with no `content` prop
For example:
```
<Info title="My Reviews">
    <MyComponent />
</Info>
```