### PR TITLE
Add phone to data on workspace create

### DIFF
--- a/src/api/create.js
+++ b/src/api/create.js
@@ -37,6 +37,7 @@ export const createReview = (params) => {
           name: params.name,
           address: params.address,
           photo: params.photo,
+          phone: params.phone,
         }
       },
       headers: {

--- a/src/components/Review/ReviewCreate.js
+++ b/src/components/Review/ReviewCreate.js
@@ -66,9 +66,10 @@ import Button from 'react-bootstrap/Button'
       const name = placeData.name
       const address = placeData.formatted_address
       const photo = placeData.photos && placeData.photos[0].getUrl()
+      const phone = placeData.formatted_phone_number
       const token = user.token
 
-      createWorkspace({ placeId, lat, lng, name, address, photo, token })
+      createWorkspace({ placeId, lat, lng, name, address, photo, token, phone })
         .then(data => this.submitReview(data.data.work_space.id))
     }
 


### PR DESCRIPTION
All new workspaces will be created with a `phone` attribute. This value will be a string (e.g. `"(617) 471-4742"`) or `null`. Some workspaces do not have a phone number associated with the google place id.

Screenshot:
![image](https://user-images.githubusercontent.com/34760728/80896162-74860500-8cb9-11ea-92eb-134b79221b54.png)
