### PR TITLE
Added new alert component for alt alert messages

### DIFF
--- a/src/components/BarAlert/BarAlert.js
+++ b/src/components/BarAlert/BarAlert.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import Alert from 'react-bootstrap/Alert'
+
+import './BarAlert.scss'
+
+class BarAlert extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      show: true
+    }
+  }
+
+  componentDidMount () {
+    this.timer = setInterval(() => {
+      this.setState({ show: false })
+    }, 3000)
+  }
+
+  componentWillUnmount () {
+    clearInterval(this.timer)
+  }
+
+  handleClose = () => this.setState({ show: false })
+
+  render () {
+    const { variant, message } = this.props
+    return (
+      <Alert
+        style={{
+          borderRadius: '0px',
+          width: '100vw',
+          textAlign: 'center',
+          color: 'black',
+          backgroundColor: '#a4ff2e',
+          fonSize: '11px',
+          fontFamily: 'Roboto',
+          fontWeight: '500',
+          top: '3%' }}
+        show={this.state.show}
+        variant={variant}
+        onClose={this.handleClose}
+        onClick={this.handleClose}
+        className={variant}
+      >
+        <div>{message}</div>
+      </Alert>
+    )
+  }
+}
+
+export default BarAlert

--- a/src/components/BarAlert/BarAlert.scss
+++ b/src/components/BarAlert/BarAlert.scss
@@ -1,0 +1,37 @@
+// @import '~bootstrap/scss/bootstrap';
+
+.bar {
+  top: 0%;
+  width: 100vw;
+}
+
+.container {
+  padding: 10px;
+}
+
+.close {
+  &:active,
+  &:focus {
+    outline: none;
+  }
+}
+
+@keyframes light-bounce-in {
+  0% {
+    opacity: 0;
+    transform: translateY(20%);
+  }
+
+  50% {
+    transform: translateY(-5%);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0%);
+  }
+}
+
+.danger {
+  top: 9%;
+}


### PR DESCRIPTION
A separate component for alternate Alert messages. This allows us to use both alert styles if we choose. 

The styling still could use some work.

Messaging will still need to be addressed.

If we keep both styles of alerts, we'll have to add a new alert option in App.js (i.e. altAlert )

<img width="396" alt="Screen Shot 2020-05-05 at 12 11 01 AM" src="https://user-images.githubusercontent.com/54245791/81034708-0d598380-8e66-11ea-9211-bcb14350d355.png">
