### PR TITLE
Redirect to '/first-signin' from header auth

### DIFF
--- a/src/components/HeaderAuthOptions/HeaderSignUp/HeaderSignUp.js
+++ b/src/components/HeaderAuthOptions/HeaderSignUp/HeaderSignUp.js
@@ -40,7 +40,7 @@ class HeaderSignUp extends Component {
         variant: 'light',
         image: 'logo-text-only.svg'
       }))
-      .then(() => history.push('/'))
+      .then(() => history.push('/first-signin'))
       .catch(error => {
         console.error(error)
         this.setState({ email: '', username: '', password: '', passwordConfirmation: '' })


### PR DESCRIPTION
The code was working for the component at '/sign-up' however we also added a sign-up component inside the header. Updated the redirect to '/first-signin' from `HeaderSignUp`.
