### PR TITLE
Changed styling on reviewCreate alert message

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -162,9 +162,8 @@ class App extends React.Component {
                 setUser={this.setUser}
                 setApp={this.setState.bind(this)}
                 google={this.state.google}
-                map={this.state.map} 
-                barAlert={this.barAlert}
-                setUser={this.setUser}/>
+                map={this.state.map}
+                barAlert={this.barAlert}/>
             )} />
 
             <Route user={user} path='/create-workspace' render={() => (

--- a/src/components/AutoAlert/AutoAlert.js
+++ b/src/components/AutoAlert/AutoAlert.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Alert from 'react-bootstrap/Alert'
+import { Row, Col } from 'react-bootstrap';
 
 import './AutoAlert.scss'
 
@@ -36,11 +37,15 @@ class AutoAlert extends React.Component {
         className={variant}
       >
         <div className="container">
-          <Alert.Heading style={{ textAlign: 'center', color: 'grey' }}>
-            {heading}
-          </Alert.Heading>
-          <p className="alert-body" style={{ textAlign: 'center', color: 'grey' }}>{message}</p>
-            {image ? (<img src={image} className="image" alt="alert" />) : null}
+          <Row>
+            {image ? (<Col xs={6}><img src={image} className="image" alt="alert" /></Col>) : null}
+            <Col className="alert-text">
+              <Alert.Heading className="alert-header">
+                {heading}
+              </Alert.Heading>
+              <p className="alert-body">{message}</p>
+            </Col>
+          </Row>
         </div>
       </Alert>
     )

--- a/src/components/AutoAlert/AutoAlert.scss
+++ b/src/components/AutoAlert/AutoAlert.scss
@@ -11,7 +11,21 @@
   transform: translate(-50%, -45%);
   padding: 16px;
   box-shadow: 2px 4px 8px rgba(0, 0, 0, 0.25);
+  box-sizing: border-box;
   border-radius: 10px;
+  border: 1px solid #C4D3FF;
+}
+
+.alert-text {
+  margin-top: 20px;
+  top: 50%;
+}
+
+.alert-header, .alert-body {
+  color: #222222;
+  font-size: 13px;
+  font-weight: 300;
+  text-align: left;
 }
 
 .container {
@@ -26,8 +40,8 @@
 }
 
 .image {
-  width: 70%;
-  padding: 10px;
+  width: 100%;
+  padding: 20px;
 }
 
 @keyframes light-bounce-in {

--- a/src/components/Review/ReviewCreate.js
+++ b/src/components/Review/ReviewCreate.js
@@ -66,7 +66,7 @@ import Button from 'react-bootstrap/Button'
             heading: 'Thanks for your review!',
             message: messages.reviewCreateSuccess,
             variant: 'light',
-            image: 'logo-text-only.svg'
+            image: 'logo-bull-icon.svg'
           })
         })
         .catch(() => alert('create review failed'))


### PR DESCRIPTION
The changed app.js code is from a setUser prop being passed in twice, just cleaning it up. 

Not really sure how the alert for desktop is being used in signin/signup/signout/cpw, I tried to fix that up a little too and just had no idea why I couldn't target it. Anyway, that still looks the same but at least the reviewcreate alert message looks like the wireframes.