### PR TITLE
Fixed workspace marker dropping off African coast

### DIFF
--- a/src/components/GoogleMap/GoogleMap.js
+++ b/src/components/GoogleMap/GoogleMap.js
@@ -114,7 +114,7 @@ class GoogleMap extends React.Component {
     handleMarkerPOI = (props, event) => {
         this.props.setApp({ placeData: null, currentWorkspace: null })
         const placeId = event.placeId
-        const poiLocation = { lat: event.position.lat, lng: event.position.lng }
+        const poiLocation = { lat: props.position.lat, lng: props.position.lng }
         const mapCenter = poiLocation
 
         this.findExistingWorkspace(placeId)


### PR DESCRIPTION
New workspace created through search result -- had an empt lat/lng
which caused any workspace marker to be in the middle of the ocean.

** We will need to wipe the database again for the user testing tomorrow once this is merged and deployed, @GMorse19. Apologies. **