### PR TITLE
Added POI visibility on grayscale map

### DIFF
--- a/src/components/MapStyles.js
+++ b/src/components/MapStyles.js
@@ -88,16 +88,16 @@ export const greyscale = [
       "elementType": "all",
       "stylers": [
           {
-              "hue": "#000000"
+              "hue": "#bbbbbb"
           },
           {
               "saturation": -100
           },
           {
-              "lightness": -100
+              "lightness": 40
           },
           {
-              "visibility": "off"
+              "visibility": "on"
           }
       ]
   },


### PR DESCRIPTION
Something I noticed on deployed app: without POIs visible, users are not able to click on a marker and create new workspace the "traditional" way. I'll post this on Slack for the designers to weigh in as well. The levels of hue and saturation for these POI markers & labels are very customizable, so I'll let them know they can play around on Snazzy if they want to make further changes.


Before:
<img width="856" alt="Screen Shot 2020-06-14 at 7 21 04 PM" src="https://user-images.githubusercontent.com/54149327/84606440-3e20d580-ae74-11ea-819d-7e9508144dab.png">


After:
<img width="792" alt="Screen Shot 2020-06-14 at 7 19 53 PM" src="https://user-images.githubusercontent.com/54149327/84606433-26495180-ae74-11ea-8d2d-58ba5c2f41f7.png">
